### PR TITLE
whitelist usage of hashtx2 and rawtx2

### DIFF
--- a/zmq.go
+++ b/zmq.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-zeromq/zmq4"
 )
 
-var allowedTopics = []string{"hashblock", "hashtx", "rawblock", "rawtx", "discardedfrommempool", "removedfrommempoolblock", "invalidtx"}
+var allowedTopics = []string{"hashblock", "hashtx", "hashtx2", "rawblock", "rawtx", "rawtx2", "discardedfrommempool", "removedfrommempoolblock", "invalidtx"}
 
 type subscriptionRequest struct {
 	topic string


### PR DESCRIPTION
As now supported from version 1.0.10